### PR TITLE
Use reusable workflows for Terraform

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -6,71 +6,12 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  terraform:
-    name: "Terraform Apply"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: Get Token From GitHub APP
-        id: get_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.UNIR_TFM_APP_ID }}
-          private-key: ${{ secrets.UNIR_TFM_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: "Build Azure credentials JSON"
-        id: build_creds
-        run: |
-          CREDS_JSON=$(jq -nc --arg clientSecret "$AZURE_CLIENT_SECRET" \
-                            --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
-                            --arg tenantId "$AZURE_TENANT_ID" \
-                            --arg clientId "$AZURE_CLIENT_ID" \
-          '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
-          echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
-        env:
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: "Configure Azure credentials"
-        uses: azure/login@v2
-        with:
-          creds: ${{ steps.build_creds.outputs.creds }}
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Format Check"
-        run: terraform fmt -check
-
-      - name: "Terraform Init"
-        run: terraform init -input=false
-
-      - name: "Terraform Plan"
-        run: terraform plan -input=false
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: "Terraform Apply"
-        run: terraform apply -auto-approve -input=false
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  apply-changes:
+    name: "Apply Changes"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-apply-azure.yml@main
+    secrets: inherit

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -3,49 +3,12 @@ name: "Terraform Destroy"
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  destroy:
-    name: "Terraform Destroy"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: "Build Azure credentials JSON"
-        id: build_creds
-        run: |
-          CREDS_JSON=$(jq -nc --arg clientSecret "$AZURE_CLIENT_SECRET" \
-                           --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
-                           --arg tenantId "$AZURE_TENANT_ID" \
-                           --arg clientId "$AZURE_CLIENT_ID" \
-          '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
-          echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
-        env:
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: "Configure Azure credentials"
-        uses: azure/login@v2
-        with:
-          creds: ${{ steps.build_creds.outputs.creds }}
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Init"
-        run: terraform init -input=false
-
-      - name: "Terraform Destroy"
-        run: terraform destroy -auto-approve -input=false
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  destroy-resources:
+    name: "Destroy Resources"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-destroy-azure.yml@main
+    secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -5,67 +5,12 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  terraform:
-    name: "Terraform Plan"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: Get Token From GitHub APP
-        id: get_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.UNIR_TFM_APP_ID }}
-          private-key: ${{ secrets.UNIR_TFM_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: "Build Azure credentials JSON"
-        id: build_creds
-        run: |
-          CREDS_JSON=$(jq -nc --arg clientSecret "$AZURE_CLIENT_SECRET" \
-                           --arg subscriptionId "$AZURE_SUBSCRIPTION_ID" \
-                           --arg tenantId "$AZURE_TENANT_ID" \
-                           --arg clientId "$AZURE_CLIENT_ID" \
-          '{clientSecret: $clientSecret, subscriptionId: $subscriptionId, tenantId: $tenantId, clientId: $clientId}')
-          echo "creds=$CREDS_JSON" >> $GITHUB_OUTPUT
-        env:
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: "Configure Azure credentials"
-        uses: azure/login@v2
-        with:
-          creds: ${{ steps.build_creds.outputs.creds }}
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Format Check"
-        run: terraform fmt -check
-
-      - name: "Terraform Init"
-        run: terraform init -input=false
-
-      - name: "Terraform Plan"
-        run: terraform plan -out .planfile -input=false
-        env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Post PR comment
-        if: always()
-        uses: borchero/terraform-plan-comment@v2
-        with:
-          token: ${{ steps.get_token.outputs.token }}
-          planfile: .planfile
+  plan-changes:
+    name: "Plan Changes"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-plan-azure.yml@main
+    secrets: inherit


### PR DESCRIPTION
This pull request refactors the Terraform-related GitHub Actions workflows to use reusable workflows, significantly simplifying the configuration and reducing duplication. The changes include replacing inline job definitions with references to reusable workflows, adding concurrency controls, and inheriting secrets for streamlined execution.

### Refactoring to reusable workflows:

* [`.github/workflows/terraform-apply.yml`](diffhunk://#diff-0470b92c7ad1159fdc694ea0893bd0e8bfad6d78173537f0e062e5e01aaf7f5eL9-R17): Replaced the inline job setup for applying Terraform changes with a reusable workflow (`terraform-apply-azure.yml`) and added concurrency controls to prevent overlapping runs.
* [`.github/workflows/terraform-destroy.yml`](diffhunk://#diff-9dff5fac2f6cd80e8a50601fc837a18f6f01c7d944821025562e97e3d9e74d25L6-R14): Replaced the inline job setup for destroying Terraform resources with a reusable workflow (`terraform-destroy-azure.yml`) and added concurrency controls.
* [`.github/workflows/terraform-plan.yml`](diffhunk://#diff-1ca63e6aac27d170492851d93ed42746d3493ce0db3c6ee7422efa4b7e3f0b6dL8-R16): Replaced the inline job setup for planning Terraform changes with a reusable workflow (`terraform-plan-azure.yml`) and added concurrency controls.