### PR TITLE
Update reusable workflows for terraform

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -11,7 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  apply-changes:
-    name: "Apply Changes"
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-apply-azure.yml@main
+  terraform:
+    name: "TF"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-apply.yml@main
+    with:
+      cloud_provider: azure
     secrets: inherit

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -8,7 +8,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  destroy-resources:
-    name: "Destroy Resources"
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-destroy-azure.yml@main
+  terraform:
+    name: "TF"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-destroy.yml@main
+    with:
+      cloud_provider: azure
     secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -10,7 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  plan-changes:
-    name: "Plan Changes"
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-plan-azure.yml@main
+  terraform:
+    name: "TF"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-plan.yml@main
+    with:
+      cloud_provider: azure
     secrets: inherit


### PR DESCRIPTION
This pull request updates the Terraform workflows in the `.github/workflows` directory to simplify job naming and improve reusability. The changes standardize the workflow files by replacing specific job names and actions with a more generic approach that supports multiple cloud providers.

Standardization of Terraform workflows:

* [`.github/workflows/terraform-apply.yml`](diffhunk://#diff-0470b92c7ad1159fdc694ea0893bd0e8bfad6d78173537f0e062e5e01aaf7f5eL14-R18): Renamed the job from `apply-changes` to `terraform` and updated the reusable action to `terraform-apply.yml`, adding a parameter for cloud provider (`azure`).
* [`.github/workflows/terraform-destroy.yml`](diffhunk://#diff-9dff5fac2f6cd80e8a50601fc837a18f6f01c7d944821025562e97e3d9e74d25L11-R15): Renamed the job from `destroy-resources` to `terraform` and updated the reusable action to `terraform-destroy.yml`, adding a parameter for cloud provider (`azure`).
* [`.github/workflows/terraform-plan.yml`](diffhunk://#diff-1ca63e6aac27d170492851d93ed42746d3493ce0db3c6ee7422efa4b7e3f0b6dL13-R17): Renamed the job from `plan-changes` to `terraform` and updated the reusable action to `terraform-plan.yml`, adding a parameter for cloud provider (`azure`).